### PR TITLE
fix: use project source dir instead of cmake source dir

### DIFF
--- a/libuptev/CMakeLists.txt
+++ b/libuptev/CMakeLists.txt
@@ -3,11 +3,11 @@ add_custom_command(
   ${CMAKE_CURRENT_BINARY_DIR}/src/uproctrace.pb-c.c
   ${CMAKE_CURRENT_BINARY_DIR}/src/uproctrace.pb-c.h
   DEPENDS
-  ${CMAKE_SOURCE_DIR}/uproctrace.proto
+  ${PROJECT_SOURCE_DIR}/uproctrace.proto
   COMMAND
-  protoc-c --proto_path ${CMAKE_SOURCE_DIR}
+  protoc-c --proto_path ${PROJECT_SOURCE_DIR}
            --c_out ${CMAKE_CURRENT_BINARY_DIR}/src
-           ${CMAKE_SOURCE_DIR}/uproctrace.proto
+           ${PROJECT_SOURCE_DIR}/uproctrace.proto
 )
 
 add_library(

--- a/python3/uproctrace/CMakeLists.txt
+++ b/python3/uproctrace/CMakeLists.txt
@@ -11,11 +11,11 @@ add_custom_command(
   OUTPUT
   ${PYTHON_UPT_DIR}/uproctrace_pb2.py
   DEPENDS
-  ${CMAKE_SOURCE_DIR}/uproctrace.proto
+  ${PROJECT_SOURCE_DIR}/uproctrace.proto
   COMMAND
-  protoc --proto_path ${CMAKE_SOURCE_DIR}
+  protoc --proto_path ${PROJECT_SOURCE_DIR}
          --python_out ${PYTHON_UPT_DIR}
-         ${CMAKE_SOURCE_DIR}/uproctrace.proto
+         ${PROJECT_SOURCE_DIR}/uproctrace.proto
 )
 install(
   FILES


### PR DESCRIPTION
Use PROJECT_SOURCE_DIR instead of CMAKE_SOURCE_DIR to allow adding uproctrace as a sub-project.