### PR TITLE
add additional tool command to dump trace statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ apt-get install -y build-essential cmake gcc \
                    libprotobuf-c-dev libprotobuf-dev \
                    ninja-build \
                    protobuf-c-compiler protobuf-compiler \
-                   pylint3 python3 python3-protobuf
+                   pylint3 python3 python3-protobuf python3-tabulate
 ```
 
 For the graphical user interface, install the additional dependencies:

--- a/python3/uproctrace/CMakeLists.txt
+++ b/python3/uproctrace/CMakeLists.txt
@@ -70,6 +70,7 @@ pyfile(dump)
 pyfile(gui)
 pyfile(parse)
 pyfile(processes)
+pyfile(stats)
 pyfile(tool)
 
 add_custom_target(

--- a/python3/uproctrace/stats.py
+++ b/python3/uproctrace/stats.py
@@ -1,0 +1,81 @@
+# UProcTrace: User-space Process Tracing
+# Copyright 2020: Florian Walbroel, Bonn, Germany <florian@hswalbroel.de>
+# Copyleft: GNU LESSER GENERAL PUBLIC LICENSE version 3 (see LICENSE)
+"""
+Statistics for uproctrace trace files.
+"""
+
+import tabulate
+import uproctrace.processes
+
+# Map of process attribute to attribute title and unit
+_PROCESS_ATTRS = {
+    "cpu_time": ("CPU Time", "s"),
+    "sys_time": ("Kernel Time", "s"),
+    "user_time": ("User Time", "s"),
+    "in_block": ("Fileystem Input Operations", ""),
+    "ou_block": ("Fileystem Output Operations", ""),
+    "maj_flt": ("Major page fault count", ""),
+    "min_flt": ("Minor page fault count", ""),
+    "max_rss_kb": ("Maximum Resident Set Size", "KiB"),
+}
+
+
+def calculate_stats(upt_traces: list) -> dict:
+    """
+    Calculates trace statistics, such like the CPU time of processes, for
+    the given list of traces and returns mapping of process attribute to
+    tuple of (min value, mean value, max value, cummulative value).
+    """
+
+    # The overall statistics
+    attr_values = dict((attr, []) for attr in _PROCESS_ATTRS)
+
+    for upt_trace in upt_traces:
+
+        # Load all processes of the trace file
+        with open(upt_trace, "rb") as f:
+            processes = uproctrace.processes.Processes(f)
+
+        for process in processes._all_processes.values():
+
+            # Ignore processes for which we do not have full information
+            if process._begin is None or process._end is None:
+                continue
+
+            # Update the values
+            for attr in _PROCESS_ATTRS:
+                attr_values[attr].append(getattr(process, attr))
+
+    # Calulate the statistics
+    stats = dict()
+    for attr, values in attr_values.items():
+        if len(values) == 0:
+            stats[attr] = (0, 0, 0, 0)
+            continue
+
+        vmin = min(values)
+        vmax = max(values)
+        vcum = sum(values)
+        vmean = vcum / len(values)
+        stats[attr] = (vmin, vmean, vmax, vcum)
+
+    return stats
+
+
+def dump_stats(upt_traces: list):
+    """
+    Calculates trace statistics, such like the CPU time of processes, for
+    the given list of traces and dumps the statistics to standard output as
+    a table.
+    """
+    # Calulate the statistics
+    stats = calculate_stats(upt_traces)
+
+    rows = []
+    for attr, values in stats.items():
+        title, unit = _PROCESS_ATTRS[attr]
+        rows += [[title] + [f"{v:.2f}{unit:s}" for v in values]]
+
+    headers = ["Attribute", "Min", "Mean", "Max", "Cumulative"]
+    print(tabulate.tabulate(rows, headers=headers))

--- a/python3/uproctrace/tool.py
+++ b/python3/uproctrace/tool.py
@@ -1,7 +1,6 @@
 # UProcTrace: User-space Process Tracing
 # Copyright 2020: Stefan Schuermans, Aachen, Germany <stefan@schuermans.info>
 # Copyleft: GNU LESSER GENERAL PUBLIC LICENSE version 3 (see LICENSE)
-
 """
 Command line interface of UProcTrace: "upt-tool".
 """
@@ -16,17 +15,42 @@ def dump(args):
     Dump all events in trace file to standard output.
     """
     import uproctrace.dump
-    with open(args.trace, 'rb') as proto_file:
-        while uproctrace.dump.dump_event(proto_file, sys.stdout):
-            pass
+    for upt_trace in args.trace:
+        if len(args.trace) != 1:
+            print(f"[{upt_trace:s}]:")
+        with open(upt_trace, 'rb') as proto_file:
+            while uproctrace.dump.dump_event(proto_file, sys.stdout):
+                pass
+        if len(args.trace) != 1:
+            print("")
+
+
+def stats(args):
+    """
+    Calculate trace statistics of trace file(s) and dump them to standard
+    output.
+    """
+    import uproctrace.stats
+    if not args.per_trace:
+        uproctrace.stats.dump_stats(args.trace)
+        return
+    for upt_trace in args.trace:
+        print(f"[{upt_trace:s}]:")
+        uproctrace.stats.dump_stats([upt_trace])
+        print("")
 
 
 def gui(args):
     """
     Run the graphical user interface.
     """
+    if len(args.trace) != 1:
+        print(
+            "error: upt-tool gui: only one trace file allowed",
+            file=sys.stderr)
+        return 1
     import uproctrace.gui
-    uproctrace.gui.run(args.trace)
+    uproctrace.gui.run(args.trace[0])
 
 
 def pstree(args):
@@ -34,25 +58,29 @@ def pstree(args):
     Print process tree.
     """
     import uproctrace.processes
-    with open(args.trace, 'rb') as proto_file:
-        processes = uproctrace.processes.Processes(proto_file)
-    # tree output (iterative)
-    to_be_output = [processes.toplevel]
-    while to_be_output:
-        procs = to_be_output[-1]
-        if not procs:
-            del to_be_output[-1]
-            continue
-        indent = '  ' * (len(to_be_output) - 1)
-        proc = procs[0]
-        del procs[0]
-        cmdline = proc.cmdline
-        if cmdline is None:
-            cmdline_str = '???'
-        else:
-            cmdline_str = ' '.join([shlex.quote(s) for s in cmdline])
-        print(indent + cmdline_str)
-        to_be_output.append(proc.children)
+    for upt_trace in args.trace:
+        if len(args.trace) != 1:
+            print(f"[{upt_trace:s}]:")
+        with open(upt_trace, 'rb') as proto_file:
+            processes = uproctrace.processes.Processes(proto_file)
+
+        # tree output (iterative)
+        to_be_output = [processes.toplevel]
+        while to_be_output:
+            procs = to_be_output[-1]
+            if not procs:
+                del to_be_output[-1]
+                continue
+            indent = '  ' * (len(to_be_output) - 1)
+            proc = procs[0]
+            del procs[0]
+            cmdline = proc.cmdline
+            if cmdline is None:
+                cmdline_str = '???'
+            else:
+                cmdline_str = ' '.join([shlex.quote(s) for s in cmdline])
+            print(indent + cmdline_str)
+            to_be_output.append(proc.children)
 
 
 def parse_args():
@@ -61,18 +89,55 @@ def parse_args():
     """
     # set up main parser
     parser = argparse.ArgumentParser(description='UProcTrace tool.')
-    parser.add_argument('trace', metavar='<trace.upt>', help='trace file')
+    parser.add_argument(
+        'trace',
+        metavar='<trace.upt>',
+        nargs='+',
+        help="""
+        The UPT trace file(s).
+        """)
+
+    # Create sub parsers
     subparsers = parser.add_subparsers()
+
     # dump
-    dump_parser = subparsers.add_parser('dump', help='Dump events to stdout.')
+    dump_parser = subparsers.add_parser(
+        'dump', help="""
+        Dump events to stdout.
+        """)
     dump_parser.set_defaults(func=dump)
+
     # gui
-    gui_parser = subparsers.add_parser('gui',
-                                       help='Run graphical user interface.')
+    gui_parser = subparsers.add_parser(
+        'gui',
+        help="""
+        Run graphical user interface. Only supports a single trace file.
+        """)
     gui_parser.set_defaults(func=gui)
+
     # pstree
-    pstree_parser = subparsers.add_parser('pstree', help='Print process tree.')
+    pstree_parser = subparsers.add_parser(
+        'pstree', help="""
+        Print process tree.
+        """)
     pstree_parser.set_defaults(func=pstree)
+
+    # stats
+    stats_parser = subparsers.add_parser(
+        'stats', help="""
+      Dump trace statistics to stdout.
+      """)
+    stats_parser.add_argument(
+        "-p",
+        "--per-trace",
+        default=False,
+        action="store_true",
+        help="""
+        If to calculate trace statistics per individual trace, instead of
+        calculating statistics over all traces.
+        """)
+    stats_parser.set_defaults(func=stats)
+
     # parse
     args = parser.parse_args()
     if not hasattr(args, 'func'):
@@ -87,4 +152,4 @@ def main():
     Parse command line arguments and execute selected action.
     """
     args = parse_args()
-    args.func(args)
+    sys.exit(args.func(args))


### PR DESCRIPTION
Enables "upt-tool" to handle multiple trace files. Adds additional command to "stats" to dump trace statistics, such as (min, mean, max, cumulative) CPU time, page faults, etc., to standard output.