### PR TITLE
fix read_file: close file on success

### DIFF
--- a/libuptev/src/read_file.c
+++ b/libuptev/src/read_file.c
@@ -42,8 +42,9 @@ char *uptev_read_file(char const *pathname, size_t *size) {
       return NULL;
     }
     if (len == 0) {
-      /* end of file -> return data */
+      /* end of file -> close file and return data */
       *size = pos;
+      close(fd);
       return data;
     }
     /* data read -> add to buffer */


### PR DESCRIPTION
The file is left open when reading succeeds. This fixes it.