### PR TITLE
fix process creation from process end event

### DIFF
--- a/python3/uproctrace/gui.py
+++ b/python3/uproctrace/gui.py
@@ -466,7 +466,8 @@ class UptGui:
                 [proc.n_iv_csw, proc.n_v_csw])
         add('CPU time', duration2str(proc.cpu_time))
         add('end time', timestamp2str(proc.end_timestamp))
-        add_list('environment', sorted(proc.environ))
+        add_list('environment',
+                 sorted(proc.environ) if proc.environ is not None else None)
         add('executable', proc.exe)
         add_sum('file system operations', ['input', 'output'],
                 [proc.in_block, proc.ou_block])

--- a/python3/uproctrace/processes.py
+++ b/python3/uproctrace/processes.py
@@ -322,6 +322,7 @@ class Processes(uproctrace.parse.Visitor):
             proc = self._current_processes[proc_end.pid]
         else:
             proc = self._newProcess(proc_end.pid)
+            self._toplevel_processes.append(proc)  # unknown parent -> toplevel
         # set end event of process and process of end event
         proc.setEnd(proc_end)
         proc_end.setProcess(proc)


### PR DESCRIPTION
Processes created from a process end event (when process begin was missed) did not show up in toplevel processes, so not in GUI.

Furthermore, there was a crash in sorting environment strings when there were none.