### PR TITLE
Schuermans.improve fork support

### DIFF
--- a/libuptev/src/proc_end.c
+++ b/libuptev/src/proc_end.c
@@ -34,6 +34,10 @@ int uptev_proc_end(void **data, size_t *size) {
 
   struct _Uproctrace__ProcEnd proc_end = UPROCTRACE__PROC_END__INIT;
   proc_end.pid = getpid();
+  // ppid also in end event because child of fork() has no begin event
+  proc_end.has_ppid = 1;
+  proc_end.ppid = getppid();
+
   proc_end.cpu_time = &cpu_time;
 
   struct rusage usage;

--- a/python3/uproctrace/gui.py
+++ b/python3/uproctrace/gui.py
@@ -131,6 +131,15 @@ def kb2str(size_kb: int) -> str:
     return txt
 
 
+def str2str(str_or_none: str) -> str:
+    """
+    Convert string (or None) to string.
+    """
+    if str_or_none is None:
+        return '???'
+    return str_or_none
+
+
 def timestamp2str(timestamp: float) -> str:
     """
     Convert a timestamp to a human-reable time string."
@@ -406,6 +415,7 @@ class UptGui:
         """
         Show details of process.
         """
+        # pylint: disable=R0914
         # forget old details
         self.wid_details_tree.clear()
         # leave if invalid proc_id
@@ -443,6 +453,13 @@ class UptGui:
                 add(f'{key} {i:d}', value, list_iter)
             return list_iter
 
+        def add_list_sorted(key: str, values: list, parent_iter=None):
+            """
+            Wrapper for add_list(...) that sorts the list (if any) before.
+            """
+            values_sorted = sorted(values) if values is not None else None
+            return add_list(key, values_sorted, parent_iter)
+
         def add_sum(key: str, sub_keys: list, values: list, parent_iter=None):
             """
             Add a sum of multiple values to a process and include individual
@@ -466,19 +483,18 @@ class UptGui:
                 [proc.n_iv_csw, proc.n_v_csw])
         add('CPU time', duration2str(proc.cpu_time))
         add('end time', timestamp2str(proc.end_timestamp))
-        add_list('environment',
-                 sorted(proc.environ) if proc.environ is not None else None)
-        add('executable', proc.exe)
+        add_list_sorted('environment', proc.environ)
+        add('executable', str2str(proc.exe))
         add_sum('file system operations', ['input', 'output'],
                 [proc.in_block, proc.ou_block])
         add('max. resident memory', kb2str(proc.max_rss_kb))
         add_sum('page faults', ['major', 'minor'],
                 [proc.maj_flt, proc.min_flt])
-        add('pid', str(proc.pid))
-        add('ppid', str(proc.ppid))
+        add('pid', int2str(proc.pid))
+        add('ppid', int2str(proc.ppid))
         add('system CPU time', duration2str(proc.sys_time))
         add('user CPU time', duration2str(proc.user_time))
-        add('working directory', proc.cwd)
+        add('working directory', str2str(proc.cwd))
         # add parent
         parent_proc = proc.parent
         if parent_proc is None:

--- a/python3/uproctrace/parse.py
+++ b/python3/uproctrace/parse.py
@@ -82,6 +82,7 @@ class ProcBeginOrEnd(BaseEvent):
         super().__init__(pb2_ev)
         self._process = None
         self._pid = None
+        self._ppid = None
 
     @property
     def pid(self) -> int:
@@ -89,6 +90,13 @@ class ProcBeginOrEnd(BaseEvent):
         ID of process.
         """
         return self._pid
+
+    @property
+    def ppid(self) -> int:
+        """
+        ID of parent process.
+        """
+        return self._ppid
 
     @property
     def process(self):
@@ -122,13 +130,6 @@ class ProcBegin(ProcBeginOrEnd):
             p_b.cmdline) if p_b.HasField('cmdline') else None
         self._environ = self._pb2GetStringList(
             p_b.environ) if p_b.HasField('environ') else None
-
-    @property
-    def ppid(self) -> int:
-        """
-        ID of parent process.
-        """
-        return self._ppid
 
     @property
     def exe(self) -> str:
@@ -173,6 +174,7 @@ class ProcEnd(ProcBeginOrEnd):
         super().__init__(pb2_ev)
         p_e = pb2_ev.proc_end
         self._pid = p_e.pid
+        self._ppid = p_e.ppid if p_e.HasField('ppid') else None
         self._cpu_time = self._pb2GetTimespec(
             p_e.cpu_time) if p_e.HasField('cpu_time') else None
         self._user_time = self._pb2GetTimespec(
@@ -187,13 +189,6 @@ class ProcEnd(ProcBeginOrEnd):
         self._ou_block = p_e.ou_block if p_e.HasField('ou_block') else None
         self._n_v_csw = p_e.n_v_csw if p_e.HasField('n_v_csw') else None
         self._n_iv_csw = p_e.n_iv_csw if p_e.HasField('n_iv_csw') else None
-
-    @property
-    def pid(self) -> int:
-        """
-        ID of process.
-        """
-        return self._pid
 
     @property
     def cpu_time(self) -> float:

--- a/python3/uproctrace/processes.py
+++ b/python3/uproctrace/processes.py
@@ -171,20 +171,20 @@ class Process():
         """
         Linux process ID.
         """
-        if self._begin is not None:
-            return self._begin.pid
-        if self._end is not None:
-            return self._end.pid
-        return None
+        return self._pid
 
     @property
     def ppid(self):
         """
         Linux process ID of parent process.
         """
-        if self._begin is None:
-            return None
-        return self._begin.ppid
+        if self._begin is not None:
+            if self._begin.ppid is not None:
+                return self._begin.ppid
+        if self._end is not None:
+            if self._end.ppid:
+                return self._end.ppid
+        return None
 
     @property
     def proc_id(self):
@@ -355,6 +355,10 @@ class Processes(uproctrace.parse.Visitor):
         # set end event of process and process of end event
         proc.setEnd(proc_end)
         proc_end.setProcess(proc)
+        # add process to parent if available
+        if proc_end.ppid is not None:
+            parent = self._getProcess(proc_end.ppid)
+            self._parentChild(parent, proc)
         # remove process from dict of current processes (it ended)
         #   - it is guaranteed to be in it, because it came from _getProcess()
         del self._current_processes[proc_end.pid]

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(first)
+add_subdirectory(fork)
 add_subdirectory(pylint)
 add_subdirectory(trace_build)

--- a/tests/fork/CMakeLists.txt
+++ b/tests/fork/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(
+  forkapp
+  forkapp.c
+)
+
+add_test(
+  NAME
+  fork
+  COMMAND
+  ${CMAKE_CURRENT_SOURCE_DIR}/forktest.bash ${CMAKE_BINARY_DIR}
+)

--- a/tests/fork/forkapp.c
+++ b/tests/fork/forkapp.c
@@ -1,0 +1,26 @@
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+void run(char const *path) {
+  pid_t child = fork();
+  if (child == 0) {
+    execl(path, path, NULL);
+    exit(EXIT_FAILURE);
+  } else if (child > 0) {
+    waitpid(child, NULL, 0);
+  }
+}
+
+int main() {
+  run("/bin/ls");
+  pid_t child = fork();
+  if (child == 0) {
+    run("/bin/uptime");
+  } else if (child > 0) {
+    waitpid(child, NULL, 0);
+    run("/bin/hostname");
+  }
+  return EXIT_SUCCESS;
+}

--- a/tests/fork/forkapp.pstree_ref
+++ b/tests/fork/forkapp.pstree_ref
@@ -1,5 +1,6 @@
-__UPT_HOME__/tests/fork/forkapp
-  /bin/ls
-  ???
-    /bin/uptime
-  /bin/hostname
+???
+  __UPT_HOME__/tests/fork/forkapp
+    /bin/ls
+    ???
+      /bin/uptime
+    /bin/hostname

--- a/tests/fork/forkapp.pstree_ref
+++ b/tests/fork/forkapp.pstree_ref
@@ -1,0 +1,5 @@
+__UPT_HOME__/tests/fork/forkapp
+  /bin/ls
+  ???
+    /bin/uptime
+  /bin/hostname

--- a/tests/fork/forktest.bash
+++ b/tests/fork/forktest.bash
@@ -1,0 +1,24 @@
+#! /bin/bash
+
+set -eux -o pipefail
+
+if (( $# < 1 ))
+then
+  echo "usage: $0 <UPT_HOME>" >&2
+  exit 2
+fi
+UPT_HOME="$1"
+
+SCRIPT_DIR="$(dirname "$0")"
+
+source "$UPT_HOME/exports"
+
+rm -rf forkapp.upt
+
+upt-trace forkapp.upt "$UPT_HOME/tests/fork/forkapp"
+
+upt-tool forkapp.upt pstree | tee forkapp.pstree
+
+sed -e "s%__UPT_HOME__%$UPT_HOME%" "$SCRIPT_DIR/forkapp.pstree_ref" \
+  >forkapp.pstree_ref
+diff -u forkapp.pstree forkapp.pstree_ref

--- a/uproctrace.proto
+++ b/uproctrace.proto
@@ -22,6 +22,8 @@ message proc_begin {
 
 message proc_end {
   required int32 pid = 1;
+  optional int32 ppid = 12; ///< pid of parent process (important for fork(),
+                            ///< because child of fork has no proc_begin event)
   /// fields from clock_gettime
   //@{
   optional timespec cpu_time = 2; ///< CPU time usage


### PR DESCRIPTION
Adding the ppid to the end event and creating processes when they are mentioned as parent in the trace enables proper process tress for binaries that fork() without calling execve() on the fork child.